### PR TITLE
Implements UsageString.

### DIFF
--- a/UsageString.wl
+++ b/UsageString.wl
@@ -1,0 +1,46 @@
+(* ::Package:: *)
+
+(* ::Title:: *)
+(*UsageString*)
+
+
+(* ::Text:: *)
+(*See on GitHub: https://github.com/maxitg/WLUsageString.*)
+
+
+BeginPackage["UsageString`"];
+
+
+Unprotect @ UsageString;
+
+
+Begin["`Private`"];
+
+
+$ArgStyle[arg_Integer] := "TR";
+$ArgStyle["\[Ellipsis]"] := "TR";
+$ArgStyle[str_String] := "TI";
+
+
+$ArgString[arg_] :=
+	"\!\(\*StyleBox[\"" <> ToString[arg] <> "\", \"" <> $ArgStyle[arg] <> "\"]\)"
+
+
+UsageString[str__] :=
+	(StringTemplate[StringJoin[{str}]] /. {TemplateSlot[s_] :> $ArgString[s]})[]
+
+
+UsageString::usage = UsageString[
+	"UsageString[\!\(\*SubscriptBox[\(`s`\), \(`1`\)]\), \!\(\*SubscriptBox[\(`s`\), \(`2`\)]\), `\[Ellipsis]`] yields a usage string where \!\(\*SubscriptBox[\(`s`\), \(`i`\)]\) are concatenated ",
+	"and slots enclosed by \` inside of them are rendered in italic similar to official ",
+	"Wolfram Language documentation."
+];
+
+
+End[];
+
+
+Protect @ UsageString;
+
+
+EndPackage[];

--- a/UsageString.wl
+++ b/UsageString.wl
@@ -30,10 +30,14 @@ UsageString[str__] :=
 	(StringTemplate[StringJoin[{str}]] /. {TemplateSlot[s_] :> $ArgString[s]})[]
 
 
-UsageString::usage = UsageString[
-	"UsageString[\!\(\*SubscriptBox[\(`s`\), \(`1`\)]\), \!\(\*SubscriptBox[\(`s`\), \(`2`\)]\), `\[Ellipsis]`] yields a usage string where \!\(\*SubscriptBox[\(`s`\), \(`i`\)]\) are concatenated ",
-	"and slots enclosed by \` inside of them are rendered in italic similar to official ",
-	"Wolfram Language documentation."
+UsageString::usage = StringJoin[
+	UsageString[
+		"UsageString[\!\(\*SubscriptBox[\(`s`\), \(`1`\)]\), ",
+		"\!\(\*SubscriptBox[\(`s`\), \(`2`\)]\), `\[Ellipsis]`] yields a usage string where ",
+		"\!\(\*SubscriptBox[\(`s`\), \(`i`\)]\) are concatenated and slots enclosed by `",
+		" are rendered in italic similar to official Wolfram Language documentation."],
+	"\nFor example, UsageString[\"f[`x`] yields f of `x`.\"] ",
+	UsageString["will render `x` in italic."]
 ];
 
 


### PR DESCRIPTION
## Changes

* Provides initial implementation of UsageString.

## Tests

* Import .wl package.
* Call `UsageString["f[`x`] yields application of", "f to `x`."]`
* Verify x is rendered in italics.