### PR TITLE
Paclet build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Build/
+*.paclet

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,0 +1,8 @@
+Paclet[
+    Name -> "UsageString",
+    Version -> "1.0",
+    MathematicaVersion -> "12.0+",
+    Description -> "Small package implementing UsageString, which produces usage strings with nice italic font for arguments.",
+    Creator -> "Maksim Piskunov",
+    Extensions -> {{"Application", Context -> "UsageString`"}}
+]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,6 +1,6 @@
 Paclet[
     Name -> "UsageString",
-    Version -> "1.0",
+    Version -> "1.1",
     MathematicaVersion -> "12.0+",
     Description -> "Small package implementing UsageString, which produces usage strings with nice italic font for arguments.",
     Creator -> "Maksim Piskunov",

--- a/build.wls
+++ b/build.wls
@@ -1,0 +1,25 @@
+#!/usr/bin/env wolframscript
+(* ::Package:: *)
+
+(* ::Text:: *)
+(*Create build directory*)
+
+
+buildDirectory = FileNameJoin[{".", "Build"}];
+If[FileExistsQ[buildDirectory], DeleteDirectory[buildDirectory, DeleteContents -> True]];
+CreateDirectory[buildDirectory];
+
+
+(* ::Text:: *)
+(*Copy package files inside*)
+
+
+files = {"UsageString.wl", "PacletInfo.m"};
+CopyFile[FileNameJoin[{".", #}], FileNameJoin[{buildDirectory, #}]] & /@ files;
+
+
+(* ::Text:: *)
+(*Pack paclet*)
+
+
+PacletManager`PackPaclet[buildDirectory];


### PR DESCRIPTION
## Changes

Adds a build script that creates a paclet.

## Commands & testing

* Run `wolframscript build.wls` to create a paclet.
* Then, evaluate Evaluate ```PacletManager`PacletInstall["path_to_paclet"]``` in Mathematica to install it.
* Try using `UsageString` to see if it is installed successfully.